### PR TITLE
Clean up build.sh by removing commented line

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -162,7 +162,7 @@ dnf5 -y copr enable loteran/arctis-sound-manager
 
 # install packages from copr
 dnf5 install -y \
-    arctis-sound-manager \
+   # arctis-sound-manager \
     kwin-effect-roundcorners
 
 ### Re-enable Deck-specific changes on top of the DX base image.

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -162,7 +162,6 @@ dnf5 -y copr enable loteran/arctis-sound-manager
 
 # install packages from copr
 dnf5 install -y \
-   # arctis-sound-manager \
     kwin-effect-roundcorners
 
 ### Re-enable Deck-specific changes on top of the DX base image.


### PR DESCRIPTION
Removed commented-out line for arctis-sound-manager installation.